### PR TITLE
Fix IPFS link

### DIFF
--- a/components/UploadToIpfs.vue
+++ b/components/UploadToIpfs.vue
@@ -55,7 +55,7 @@ export default {
                 body: formData
               })
             this.file = await response.json()
-            this.$emit('upload', `${this.ipfsExplorer}/${this.file.Hash}`)
+            this.$emit('upload', `${this.ipfsExplorer}/ipfs/${this.file.Hash}`)
             this.selectedFile = null
             this.$refs.file.value = ''
           }


### PR DESCRIPTION
The current behaviour results in:
```
https://ipfs.effect.ai/QmQzKni5Z2sMsLPiARny62bJBSu2FW3FV2Axn83wiMVZLe
```
after upload, while it should have been:
```
https://ipfs.effect.ai/ipfs/QmQzKni5Z2sMsLPiARny62bJBSu2FW3FV2Axn83wiMVZLe
```